### PR TITLE
Fix timer to keep running when tab is inactive

### DIFF
--- a/modules/timer.js
+++ b/modules/timer.js
@@ -1,23 +1,39 @@
 export function createTimer({ onTick, onDone }) {
-  let running = false, last = 0, remaining = 0, rafId = null;
+  let running = false,
+    last = 0,
+    remaining = 0,
+    timeoutId = null;
 
   function start(ms) {
     remaining = ms;
-    running = true; last = performance.now();
+    running = true;
+    last = performance.now();
     tick();
   }
+
   function resume() {
     if (remaining <= 0) return;
-    running = true; last = performance.now();
+    running = true;
+    last = performance.now();
     tick();
   }
-  function pause() { running = false; cancelAnimationFrame(rafId); }
-  function reset(ms) { pause(); remaining = ms; onTick?.(remaining); }
+
+  function pause() {
+    running = false;
+    clearTimeout(timeoutId);
+  }
+
+  function reset(ms) {
+    pause();
+    remaining = ms;
+    onTick?.(remaining);
+  }
 
   function tick() {
     if (!running) return;
     const now = performance.now();
-    const dt = now - last; last = now;
+    const dt = now - last;
+    last = now;
     remaining -= dt;
     if (remaining <= 0) {
       running = false;
@@ -26,7 +42,7 @@ export function createTimer({ onTick, onDone }) {
       return;
     }
     onTick?.(remaining);
-    rafId = requestAnimationFrame(tick);
+    timeoutId = setTimeout(tick, 100);
   }
 
   return { start, resume, pause, reset, getRemaining: () => remaining };


### PR DESCRIPTION
## Summary
- replace `requestAnimationFrame` with `setTimeout` so the timer continues ticking when the browser tab is inactive
- ensure pause clears the scheduled timeout and timer still accounts for elapsed time

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7db95bc24832abb38d585cc95078a